### PR TITLE
Quickfix for Windows support

### DIFF
--- a/src/associatedfiles.plugin.coffee
+++ b/src/associatedfiles.plugin.coffee
@@ -27,7 +27,7 @@ module.exports = (BasePlugin) ->
 				documentAssociatedFilesPath = @get('associatedFilesPath') or @get('basename')
 				documentAssociatedFilesPathNormalized = @getPath(documentAssociatedFilesPath, associatedFilesPath)
 				unless documentAssociatedFilesPathNormalized.slice(-1) in ['\\','/']
-					documentAssociatedFilesPathNormalized += '/'
+					documentAssociatedFilesPathNormalized += pathUtil.sep
 				return documentAssociatedFilesPathNormalized
 			DocumentModel::getAssociatedFiles = (sorting,paging) ->
 				# Prepare


### PR DESCRIPTION
Plugin wouldn't work on my Windows system due to a hard-coded Unix path separator.
