### PR TITLE
Added option to use relativeBase, for subdirectory support.

### DIFF
--- a/src/associatedfiles.plugin.coffee
+++ b/src/associatedfiles.plugin.coffee
@@ -8,6 +8,7 @@ module.exports = (BasePlugin) ->
 		# Plugin config
 		config:
 			associatedFilesPath: 'associated-files'
+			useRelativeBase: false
 			sorting: null  # [name:1, date:-1]
 			paging: null  # {limit: 1}
 
@@ -27,7 +28,8 @@ module.exports = (BasePlugin) ->
 
 			# Extend our prototype
 			DocumentModel::getAssociatedFilesPath = ->
-				documentAssociatedFilesPath = @get('associatedFilesPath') or @get('basename')
+				documentBase = if config.useRelativeBase then @get('relativeBase') else @get('basename')
+				documentAssociatedFilesPath = @get('associatedFilesPath') or documentBase
 				documentAssociatedFilesPathNormalized = @getPath(documentAssociatedFilesPath, associatedFilesPath)
 				unless documentAssociatedFilesPathNormalized.slice(-1) in ['\\','/']
 					documentAssociatedFilesPathNormalized += pathUtil.sep


### PR DESCRIPTION
My documents are organized in `/posts`, `/projects`, etc. I wanted the associated files to follow the same structure.

Added an option `useRelativeBase` that tells the plugin to use `relativeBase`, instead of `basename`.
