### PR TITLE
Added 'useRelativeDirPath' config option

### DIFF
--- a/src/associatedfiles.plugin.coffee
+++ b/src/associatedfiles.plugin.coffee
@@ -8,6 +8,7 @@ module.exports = (BasePlugin) ->
 		# Plugin config
 		config:
 			associatedFilesPath: 'associated-files'
+			useRelativeDirPath: false
 			sorting: null  # [name:1, date:-1]
 			paging: null  # {limit: 1}
 
@@ -28,7 +29,10 @@ module.exports = (BasePlugin) ->
 			# Extend our prototype
 			DocumentModel::getAssociatedFilesPath = ->
 				documentAssociatedFilesPath = @get('associatedFilesPath') or @get('basename')
-				documentAssociatedFilesPathNormalized = @getPath(documentAssociatedFilesPath, associatedFilesPath)
+				_associatedFilesPath = associatedFilesPath
+				if config.useRelativeDirPath
+					_associatedFilesPath += pathUtil.sep + @get('relativeDirPath')
+				documentAssociatedFilesPathNormalized = @getPath(documentAssociatedFilesPath, _associatedFilesPath)
 				unless documentAssociatedFilesPathNormalized.slice(-1) in ['\\','/']
 					documentAssociatedFilesPathNormalized += pathUtil.sep
 				return documentAssociatedFilesPathNormalized


### PR DESCRIPTION
Added a `useRelativeDirPath` config option that appends the document's relative directory path to the associated files path.

This allows you to organise your associated files in a more structured way, and one which mirrors the document the files are associated with.  For example, if your document lives at `/documents/posts/2012/post1.html.md` and `useRelativeDirPath` is set to true, then the plugin will look for associated files at `/files/associated-files/posts/2012/post1/` rather than `/files/associated-files/post1/`.
